### PR TITLE
Remove commented stateProvince as not needed

### DIFF
--- a/docs/dwc_mapping.html
+++ b/docs/dwc_mapping.html
@@ -11,7 +11,7 @@
 
 <meta name="author" content="Damiano Oldoni" />
 
-<meta name="date" content="2022-10-14" />
+<meta name="date" content="2022-10-19" />
 
 <title>Darwin Core mapping</title>
 
@@ -356,7 +356,7 @@ div.tocify {
 <h3 class="subtitle">For: monitoring of invasive alien crayfishes in the
 Flemish part of the LIFE RIPARIAS areas</h3>
 <h4 class="author">Damiano Oldoni</h4>
-<h4 class="date">2022-10-14</h4>
+<h4 class="date">2022-10-19</h4>
 
 </div>
 
@@ -656,25 +656,25 @@ write_csv(dwc_occurrence, here::here(&quot;data&quot;, &quot;processed&quot;, &q
 ## 
 ## ℹ Use `spec()` to retrieve the full column specification for this data.
 ## ℹ Specify the column types or set `show_col_types = FALSE` to quiet this message.</code></pre>
-<pre><code>## Test passed 😀
-## Test passed 🌈
+<pre><code>## Test passed 🥳
 ## Test passed 🎊
-## Test passed 😀
-## Test passed 😀
-## Test passed 😀
 ## Test passed 🎊
 ## Test passed 😸
 ## Test passed 🎉
-## Test passed 😀
-## Test passed 🌈
-## Test passed 🌈
 ## Test passed 😸
-## Test passed 🥇
 ## Test passed 😸
 ## Test passed 🥳
+## Test passed 🥇
+## Test passed 😀
+## Test passed 🌈
 ## Test passed 🎊
-## Test passed 😸
-## Test passed 🥳</code></pre>
+## Test passed 😀
+## Test passed 😀
+## Test passed 😀
+## Test passed 🎉
+## Test passed 🌈
+## Test passed 🥳
+## Test passed 🎊</code></pre>
 </div>
 
 

--- a/sql/dwc_event.sql
+++ b/sql/dwc_event.sql
@@ -17,9 +17,6 @@ SELECT DISTINCT
   date(o."datum")                       AS eventDate,
 -- LOCATION
   'BE'                                  AS countryCode,
-  /* uncomment if needed
-  'Flanders'                            AS stateProvince,
-  */
   o."omschrijving"                      AS locality,
   printf('%.5f', ROUND(o."Y", 5))       AS decimalLatitude,
   printf('%.5f', ROUND(o."X", 5))       AS decimalLongitude,


### PR DESCRIPTION
Based on https://github.com/riparias/anb-crayfishes-occurrences/issues/13#issuecomment-1279747877, we decided to not use  `stateProvince` in event core sql mapping. The mapping of such field was already commented. With this PR is removed definitively.